### PR TITLE
Fix ios_xctestrun_runner for Xcode 15

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -197,6 +197,12 @@ bzl_library(
     deps = ["watchos"],
 )
 
+bzl_library(
+    name = "xcarchive",
+    srcs = ["xcarchive.bzl"],
+    deps = ["//apple/internal:xcarchive"],
+)
+
 # Consumed by bazel tests.
 filegroup(
     name = "for_bazel_tests",

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -676,6 +676,17 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "xcarchive",
+    srcs = ["xcarchive.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        "//apple:providers",
+    ],
+)
+
 # Consumed by bazel tests.
 filegroup(
     name = "for_bazel_tests",

--- a/apple/internal/xcarchive.bzl
+++ b/apple/internal/xcarchive.bzl
@@ -1,0 +1,99 @@
+"""
+Rule for packaging a bundle into a .xcarchive.
+"""
+
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfo",
+    "AppleBundleInfo",
+    "AppleDsymBundleInfo",
+)
+
+def _xcarchive_impl(ctx):
+    """
+    Implementation for xcarchive.
+
+    This rule uses the providers from the bundle target to re-package it into a .xcarchive.
+    The .xcarchive is a directory that contains the .app bundle, dSYM and other metadata.
+    """
+    bundle_info = ctx.attr.bundle[AppleBundleInfo]
+    dsym_info = ctx.attr.bundle[AppleDsymBundleInfo]
+    xcarchive = ctx.actions.declare_directory("%s.xcarchive" % bundle_info.bundle_name)
+
+    arguments = ctx.actions.args()
+    arguments.add("--info_plist", bundle_info.infoplist.path)
+    arguments.add("--bundle", bundle_info.archive.path)
+    arguments.add("--output", xcarchive.path)
+
+    for dsym in dsym_info.direct_dsyms:
+        arguments.add("--dsym", dsym.path)
+
+    ctx.actions.run(
+        inputs = depset([
+            bundle_info.archive,
+            bundle_info.infoplist,
+        ] + dsym_info.direct_dsyms),
+        outputs = [xcarchive],
+        executable = ctx.executable._make_xcarchive,
+        arguments = [arguments],
+        mnemonic = "XCArchive",
+    )
+
+    # Limiting the contents of AppleBinaryInfo to what is necessary for testing and validation.
+    xcarchive_binary_info = AppleBinaryInfo(
+        binary = xcarchive,
+        infoplist = None,
+        product_type = None,
+    )
+
+    return [
+        DefaultInfo(files = depset([xcarchive])),
+        xcarchive_binary_info,
+    ]
+
+xcarchive = rule(
+    implementation = _xcarchive_impl,
+    attrs = {
+        "bundle": attr.label(
+            providers = [
+                AppleBundleInfo,
+                AppleDsymBundleInfo,
+            ],
+            doc = """\
+The label to a target to re-package into a .xcarchive. For example, an
+`ios_application` target.
+            """,
+        ),
+        "_make_xcarchive": attr.label(
+            default = Label("@build_bazel_rules_apple//tools/xcarchivetool:make_xcarchive"),
+            executable = True,
+            cfg = "exec",
+            doc = """\
+An executable binary that can re-package a bundle into a .xcarchive.
+            """,
+        ),
+    },
+    doc = """\
+Re-packages an Apple bundle into a .xcarchive.
+
+This rule uses the providers from the bundle target to construct the required
+metadata for the .xcarchive.
+
+Example:
+
+````starlark
+load("@build_bazel_rules_apple//apple:xcarchive.bzl", "xcarchive")
+
+ios_application(
+    name = "App",
+    bundle_id = "com.example.my.app",
+    ...
+)
+
+xcarchive(
+    name = "App.xcarchive",
+    bundle = ":App",
+)
+````
+    """,
+)

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -159,8 +159,8 @@ if [[ -n "$test_host_path" ]]; then
     mkdir "$plugins_path/$test_bundle_name.xctest/Frameworks"
     # We need this dylib for 14.x OSes. This intentionally doesn't use `test_execution_platform`
     # since this file isn't present in the `iPhoneSimulator.platform`.
+    # No longer necessary starting in Xcode 15 - hence the `-f` file existence check
     libswift_concurrency_path="$(xcode-select -p)/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/libswift_Concurrency.dylib"
-    # This is no longer necessary in Xcode 15
     if [[ -f "$libswift_concurrency_path" ]]; then
       cp "$libswift_concurrency_path" "$plugins_path/$test_bundle_name.xctest/Frameworks/libswift_Concurrency.dylib"
     fi

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -159,7 +159,11 @@ if [[ -n "$test_host_path" ]]; then
     mkdir "$plugins_path/$test_bundle_name.xctest/Frameworks"
     # We need this dylib for 14.x OSes. This intentionally doesn't use `test_execution_platform`
     # since this file isn't present in the `iPhoneSimulator.platform`.
-    cp "$(xcode-select -p)/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/libswift_Concurrency.dylib" "$plugins_path/$test_bundle_name.xctest/Frameworks/libswift_Concurrency.dylib"
+    libswift_concurrency_path="$(xcode-select -p)/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/libswift_Concurrency.dylib"
+    # This is no longer necessary in Xcode 15
+    if [[ -f "$libswift_concurrency_path" ]]; then
+      cp "$libswift_concurrency_path" "$plugins_path/$test_bundle_name.xctest/Frameworks/libswift_Concurrency.dylib"
+    fi
     xcrun_test_bundle_path="__TESTHOST__/PlugIns/$test_bundle_name.xctest"
 
     /usr/bin/sed \

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
@@ -40,6 +40,8 @@
       <string>/DUMMY_SRCROOT/</string>
       BAZEL_TEST_ENVIRONMENT
     </dict>
+    <key>SystemAttachmentLifetime</key>
+    <string>keepNever</string>
     <key>UserAttachmentLifetime</key>
     <string>keepNever</string>
     <key>ClangProfileDataDirectoryPath</key>

--- a/apple/xcarchive.bzl
+++ b/apple/xcarchive.bzl
@@ -1,0 +1,24 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Rules for creating Xcode archives.
+"""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:xcarchive.bzl",
+    _xcarchive = "xcarchive",
+)
+
+xcarchive = _xcarchive

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -15,6 +15,7 @@ _RULES_DOC_SRCS = [
     "tvos.doc",
     "versioning",
     "watchos.doc",
+    "xcarchive",
 ]
 
 _DOC_SRCS = _PLAIN_DOC_SRCS + _RULES_DOC_SRCS

--- a/doc/README.md
+++ b/doc/README.md
@@ -106,9 +106,13 @@ below.
   </thead>
   <tbody>
     <tr>
-      <th align="left" valign="top" rowspan="2">General</th>
+      <th align="left" valign="top" rowspan="3">General</th>
       <td valign="top"><code>@build_bazel_rules_apple//apple:versioning.bzl</code></td>
       <td valign="top"><code><a href="rules-versioning.md#apple_bundle_version">apple_bundle_version</a></code><br/></td>
+    </tr>
+    <tr>
+      <td valign="top"><code>@build_bazel_rules_apple//apple:xcarchive.bzl</code></td>
+      <td valign="top"><code><a href="rules-xcarchive.md#xcarchive">xcarchive</a></code></td>
     </tr>
     <tr>
       <td valign="top"><code>@build_bazel_rules_apple//apple:apple.bzl</code></td>

--- a/doc/rules-xcarchive.md
+++ b/doc/rules-xcarchive.md
@@ -1,0 +1,46 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+Rules for creating Xcode archives.
+
+
+<a id="xcarchive"></a>
+
+## xcarchive
+
+<pre>
+xcarchive(<a href="#xcarchive-name">name</a>, <a href="#xcarchive-bundle">bundle</a>)
+</pre>
+
+Re-packages an Apple bundle into a .xcarchive.
+
+This rule uses the providers from the bundle target to construct the required
+metadata for the .xcarchive.
+
+Example:
+
+````starlark
+load("@build_bazel_rules_apple//apple:xcarchive.bzl", "xcarchive")
+
+ios_application(
+    name = "App",
+    bundle_id = "com.example.my.app",
+    ...
+)
+
+xcarchive(
+    name = "App.xcarchive",
+    bundle = ":App",
+)
+````
+    
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="xcarchive-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="xcarchive-bundle"></a>bundle |  The label to a target to re-package into a .xcarchive. For example, an <code>ios_application</code> target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+
+

--- a/examples/ios/HelloWorld/BUILD
+++ b/examples/ios/HelloWorld/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//apple:ios.bzl", "ios_application")
+load("//apple:xcarchive.bzl", "xcarchive")
 load(
     "//apple:versioning.bzl",
     "apple_bundle_version",
@@ -44,4 +45,10 @@ ios_application(
 build_test(
     name = "ExamplesBuildTest",
     targets = [":HelloWorld"],
+)
+
+# Example using xcarchive rule to create an .xcarchive bundle.
+xcarchive(
+    name = "HelloWorld.xcarchive",
+    bundle = ":HelloWorld",
 )

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -45,6 +45,7 @@ load(":watchos_framework_tests.bzl", "watchos_framework_test_suite")
 load(":watchos_static_framework_tests.bzl", "watchos_static_framework_test_suite")
 load(":watchos_ui_test_tests.bzl", "watchos_ui_test_test_suite")
 load(":watchos_unit_test_tests.bzl", "watchos_unit_test_test_suite")
+load(":xcarchive_tests.bzl", "xcarchive_test_suite")
 
 licenses(["notice"])
 
@@ -142,6 +143,8 @@ watchos_static_framework_test_suite(name = "watchos_static_framework")
 watchos_ui_test_test_suite(name = "watchos_ui_test")
 
 watchos_unit_test_test_suite(name = "watchos_unit_test")
+
+xcarchive_test_suite(name = "xcarchive")
 
 test_suite(
     name = "all_tests",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -32,6 +32,10 @@ load(
     "//test/starlark_tests:common.bzl",
     "common",
 )
+load(
+    "//apple:xcarchive.bzl",
+    "xcarchive",
+)
 
 licenses(["notice"])
 
@@ -58,6 +62,12 @@ ios_application(
     deps = [
         "//test/starlark_tests/resources:objc_main_lib",
     ],
+)
+
+xcarchive(
+    name = "app_minimal.xcarchive",
+    bundle = ":app_minimal",
+    tags = common.fixture_tags,
 )
 
 ios_application(

--- a/test/starlark_tests/xcarchive_tests.bzl
+++ b/test/starlark_tests/xcarchive_tests.bzl
@@ -1,0 +1,74 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""xcarchive Starlark tests."""
+
+load(
+    ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
+)
+
+def xcarchive_test_suite(name):
+    """Test suite for xcarchive rule.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+
+    # Verify xcarchive bundles required files and app for simulator and device.
+    archive_contents_test(
+        name = "{}_contains_xcarchive_files_simulator".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal.xcarchive",
+        contains = [
+            "$BUNDLE_ROOT/Info.plist",
+            "$BUNDLE_ROOT/Products/Applications/app_minimal.app",
+        ],
+        plist_test_file = "$BUNDLE_ROOT/Info.plist",
+        plist_test_values = {
+            "ApplicationProperties:ApplicationPath": "Products/Applications/app_minimal.app",
+            "ApplicationProperties:ArchiveVersion": 2,
+            "ApplicationProperties:CFBundleIdentifier": "com.google.example",
+            "ApplicationProperties:CFBundleShortVersionString": "1.0",
+            "ApplicationProperties:CFBundleVersion": "1.0",
+            "Name": "app_minimal",
+            "SchemeName": "app_minimal",
+        },
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_contains_xcarchive_files_device".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal.xcarchive",
+        contains = [
+            "$BUNDLE_ROOT/Info.plist",
+            "$BUNDLE_ROOT/Products/Applications/app_minimal.app",
+        ],
+        plist_test_file = "$BUNDLE_ROOT/Info.plist",
+        plist_test_values = {
+            "ApplicationProperties:ApplicationPath": "Products/Applications/app_minimal.app",
+            "ApplicationProperties:ArchiveVersion": 2,
+            "ApplicationProperties:CFBundleIdentifier": "com.google.example",
+            "ApplicationProperties:CFBundleShortVersionString": "1.0",
+            "ApplicationProperties:CFBundleVersion": "1.0",
+            "Name": "app_minimal",
+            "SchemeName": "app_minimal",
+        },
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/tools/wrapper_common/BUILD
+++ b/tools/wrapper_common/BUILD
@@ -9,6 +9,7 @@ py_library(
         "//tools/codesigningtool:__pkg__",
         "//tools/dossier_codesigningtool:__pkg__",
         "//tools/swift_stdlib_tool:__pkg__",
+        "//tools/xcarchivetool:__pkg__",
         "//tools/xctoolrunner:__pkg__",
     ],
 )

--- a/tools/xcarchivetool/BUILD
+++ b/tools/xcarchivetool/BUILD
@@ -1,0 +1,7 @@
+py_binary(
+    name = "make_xcarchive",
+    srcs = ["make_xcarchive.py"],
+    srcs_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = ["//tools/wrapper_common:execute"],
+)

--- a/tools/xcarchivetool/make_xcarchive.py
+++ b/tools/xcarchivetool/make_xcarchive.py
@@ -1,0 +1,174 @@
+import argparse
+import datetime
+import os
+import plistlib
+import re
+import shutil
+import tempfile
+import zipfile
+
+from dataclasses import dataclass
+from pathlib import Path
+from tools.wrapper_common import execute
+
+
+def _build_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    "--info_plist",
+    required=True,
+    help="The file path to the Info.plist file for the app.",
+  )
+  parser.add_argument(
+    "--bundle",
+    required=True,
+    help="The file path to the bundle.",
+  )
+  parser.add_argument(
+    "--output",
+    required=True,
+    help="The file path to the output .xcarchive.",
+  )
+  parser.add_argument(
+    "--dsym",
+    required=False,
+    action="append",
+    help="The file path to a dSYM file which will be packaged in the .xcarchive.",
+  )
+  return parser
+
+
+@dataclass
+class _CodeSignInfo:
+  authority: str
+  team: str
+
+
+def _get_codesign_info(app_path: str) -> _CodeSignInfo:
+  """Returns the codesign information for the given app bundle using codesign tool."""
+
+  _, _, output = execute.execute_and_filter_output([
+    "/usr/bin/codesign",
+    "-vv",
+    "-d",
+    app_path,
+  ], raise_on_failure=True)
+
+  authority = re.search(r'^Authority=(.*)$', str(output), re.MULTILINE)
+  team = re.search(r'^TeamIdentifier=(.*)$', str(output), re.MULTILINE)
+  team = team.group(1) if team and team.group(1) != "not set" else None
+
+  return _CodeSignInfo(
+    authority=authority.group(1) if authority else None,
+    team=team)
+
+
+def _extract_app_from_ipa(ipa_path: str, output_path: str) -> str:
+  """Extracts the .ipa to a temporary directory and copies the .app to the output directory."""
+
+  with tempfile.TemporaryDirectory(prefix="bazel_temp") as temp_dir:
+    # Unzip the .ipa to a temporary directory.
+    with open(ipa_path, "rb") as ipa_file:
+      ipa_zip = zipfile.ZipFile(ipa_file, "r")
+      ipa_zip.extractall(temp_dir)
+    # Find the .app.
+    app_path = next(Path(temp_dir).glob("**/*.app"))
+    if not app_path:
+      raise Exception(
+        "Could not find .app within the .ipa bundle located at: " + ipa_path)
+    # Copy the .app to the output directory.
+    shutil.copytree(app_path, output_path, dirs_exist_ok=True)
+
+
+def _main(
+    infoplist_path: Path,
+    bundle_path: Path,
+    output_path: Path,
+    dsyms: list):
+  """Creates a .xcarchive from the given bundle.
+
+  <BundleName>.xcarchive
+  Products/
+    Applications/
+    <BundleName>.app
+  Info.plist
+  PkgInfo
+  dSYMs/
+    <BundleName>.app.dSYM
+
+  Args:
+    infoplist_path: The file path to the Info.plist file for the app.
+    bundle_path: The file path to the bundle.
+    output_path: The file path to the output .xcarchive.
+    dsyms: The file paths to the dSYM files which will be packaged in the .xcarchive.
+  """
+
+  # Collect the required information for the .xcarchive plist
+  # from the apps Info.plist.
+  with open(infoplist_path, "rb") as f:
+    infoplist = plistlib.load(f, fmt=plistlib.FMT_BINARY)
+    bundle_name = infoplist["CFBundleName"]
+    bundle_id = infoplist["CFBundleIdentifier"]
+    bundle_version = infoplist["CFBundleVersion"]
+    short_version = infoplist["CFBundleShortVersionString"]
+
+  # Create the .xcarchive directory.
+  bundle_dest_dir = os.path.join(output_path, "Products", "Applications")
+  bundle_dest_path = os.path.join(
+    output_path, "Products", "Applications", bundle_name + ".app")
+  os.makedirs(bundle_dest_dir, exist_ok=True)
+
+  # If is an .ipa, extract and copy .app to destination
+  # Else Copy the archive contents to the destination.
+  if bundle_path.suffix == ".ipa":
+    _extract_app_from_ipa(bundle_path, bundle_dest_path)
+  else:
+    shutil.copytree(bundle_path, bundle_dest_path,
+            copy_function=shutil.copyfile,
+            dirs_exist_ok=True)
+
+  # Copy the dSYM files into the .xcarchive.
+  dsyms_path = os.path.join(output_path, "dSYMs")
+  for dsym in dsyms or []:
+    shutil.copytree(
+      dsym,
+      os.path.join(dsyms_path, os.path.basename(dsym)),
+      dirs_exist_ok=True)
+
+  # Create the Info.plist for the .xcarchive.
+  creation_date = datetime.datetime.now().isoformat()
+  app_relative_path = os.path.relpath(bundle_dest_path, output_path)
+  info_plist = {
+    "ApplicationProperties": {
+      "ApplicationPath": app_relative_path,
+      "ArchiveVersion": 2,
+      "CFBundleIdentifier": bundle_id,
+      "CFBundleShortVersionString": short_version,
+      "CFBundleVersion": bundle_version,
+    },
+    "CreationDate": creation_date,
+    "Name": bundle_name,
+    "SchemeName": bundle_name,
+  }
+
+  # Add the codesigning information to the .xcarchive Info.plist.
+  codesign_info = _get_codesign_info(bundle_dest_path)
+  if codesign_info.authority:
+    info_plist["ApplicationProperties"]["SigningIdentity"] = codesign_info.authority
+  if codesign_info.team:
+    info_plist["ApplicationProperties"]["Team"] = codesign_info.team
+
+  # Write the .xcarchive Info.plist.
+  info_plist_path = os.path.join(output_path, "Info.plist")
+  with open(info_plist_path, "wb") as f:
+    plistlib.dump(info_plist, f)
+
+
+if __name__ == "__main__":
+  args = _build_parser().parse_args()
+
+  _main(
+    Path(args.info_plist),
+    Path(args.bundle),
+    Path(args.output),
+    args.dsym)


### PR DESCRIPTION
Starting in Xcode 15 `libswift_Concurrency.dylib` no longer exists in the `iOS.simruntime` folder. I don't think it is even needed anymore, but if it is we can probably move it from some version of the below path, but trying simply removing it to see if that works.

`Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/iphoneos/libswift_Concurrency.dylib`